### PR TITLE
Update Documenter version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -1,0 +1,24 @@
+name: Documenter
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  Documenter:
+    permissions:
+      contents: write
+      statuses: write
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+          show-versioninfo: true
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-docdeploy@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~0.21"
+Documenter = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,9 @@
 [deps]
+CALCEPH = "1537fe66-4725-5aba-80f4-3a74792cecc1"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
 Documenter = "1"
+
+[sources.CALCEPH]
+path = ".."

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,16 +1,17 @@
-using Documenter, CALCEPH
+using Documenter
+using CALCEPH
 
 makedocs(
-	sitename = "CALCEPH.jl",
-	authors = "Bernard Godard and the CALCEPH.jl contributors",
-	pages = [
-		"Home" => "index.md",
-		"Tutorial" => "tutorial.md",
-		"API" => "api.md"
-	],
+    sitename = "CALCEPH.jl",
+    authors = "Bernard Godard and the CALCEPH.jl contributors",
+    pages = [
+        "Home" => "index.md",
+        "Tutorial" => "tutorial.md",
+        "API" => "api.md"
+    ],
 )
 
 deploydocs(
-	repo = "github.com/JuliaAstro/CALCEPH.jl.git",
-	target = "build",
+    repo = "github.com/JuliaAstro/CALCEPH.jl.git",
+    target = "build",
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,6 @@
 using Documenter, CALCEPH
 
 makedocs(
-    format = :html,
 	sitename = "CALCEPH.jl",
 	authors = "Bernard Godard and the CALCEPH.jl contributors",
 	pages = [

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -100,7 +100,7 @@ The more complete NAIF identification scheme can be used if the value useNaifId 
 
 ## NAIF body identification scheme
 
-See [https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/naif_ids.html](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/naif_ids.html)
+See <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/naif_ids.html>
 
 CALCEPH uses this identification scheme only when the value useNaifId is added to the options argument.
 
@@ -243,8 +243,8 @@ The time ephemeris TT-TDB or TCG-TCB at the geocenter can be evaluated with a su
 INPOP and some JPL DE ephemerides includes a numerically integrated time ephemeris for the geocenter which is usually more accurate than the analytical series: Moreover it is much faster to interpolate those ephemerides than to evaluate the analytical series. This is only for the geocenter but a simple correction can also be added for the location of the observer (and its velocity in case the observer is on a highly elliptical orbit).
 
 Files that can be used to obtain the difference between TT and TDB are, e.g.:
-- [ftp://ftp.imcce.fr/pub/ephem/planets/inpop17a/inpop17a_TDB_m100_p100_tt.dat](ftp://ftp.imcce.fr/pub/ephem/planets/inpop17a/inpop17a_TDB_m100_p100_tt.dat)
-- [ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de432t.bsp](ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de432t.bsp)
+- <ftp://ftp.imcce.fr/pub/ephem/planets/inpop17a/inpop17a_TDB_m100_p100_tt.dat>
+- <ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de432t.bsp>
 
 #### Example:
 Computing TT-TDB at geocenter in seconds at JD=2456293.5 (Ephemeris Time).

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -178,7 +178,7 @@ jd2 = 0.5
 center = naifId.id[:moon]
 target = naifId.id[:jupiter_barycenter]
 pos = compute(eph2, jd1, jd2, target, center, options,0)
-```  
+```
 
 ## Computing orientation:
 
@@ -202,7 +202,7 @@ Those methods compute the Euler angles of target and their time derivatives.
   - 3: the angles, the first, second and third derivatives are computed.
 
 #### Example:
-JPL DE405 binary ephemerides contain Chebychev polynomials for the IAU 1980 nutation theory. Interpolating those is much faster than computing the IAU 1980 nutation series.    
+JPL DE405 binary ephemerides contain Chebychev polynomials for the IAU 1980 nutation theory. Interpolating those is much faster than computing the IAU 1980 nutation series.
 Computing Earth nutation angles in radians at JD=2456293.5 (Ephemeris Time).
 ```julia
 download("ftp://ssd.jpl.nasa.gov/pub/eph/planets/Linux/de405/lnxp1600p2200.405","DE405")
@@ -246,7 +246,7 @@ Files that can be used to obtain the difference between TT and TDB are, e.g.:
 - [ftp://ftp.imcce.fr/pub/ephem/planets/inpop17a/inpop17a_TDB_m100_p100_tt.dat](ftp://ftp.imcce.fr/pub/ephem/planets/inpop17a/inpop17a_TDB_m100_p100_tt.dat)
 - [ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de432t.bsp](ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de432t.bsp)
 
-#### Example:  
+#### Example:
 Computing TT-TDB at geocenter in seconds at JD=2456293.5 (Ephemeris Time).
 ```julia
 download("ftp://ftp.imcce.fr/pub/ephem/planets/inpop17a/inpop17a_TDB_m100_p100_tt.dat","INPOP17a")
@@ -281,7 +281,7 @@ Those methods do not perform any checks on their inputs. In particular, result m
 
 Ephemerides files may contain related constants. Those can be obtained by the **constants** method which returns a dictionary:
 
-```julia  
+```julia
 download("ftp://ftp.imcce.fr/pub/ephem/planets/inpop17a/inpop17a_TDB_m100_p100_tt.dat","INPOP17a")
 eph1 = Ephem("INPOP17a")
 # retrieve constants from ephemeris as a dictionary

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -106,7 +106,7 @@ CALCEPH uses this identification scheme only when the value useNaifId is added t
 
 The CALCEPH julia wrapper comes with the naifId object which contains the mapping between NAIF identification numbers and names:
 
-```julia
+```julia-repl
 julia> naifId.id[:sun]
 10
 


### PR DESCRIPTION
- Add dependabot.yml

  Make bots maintain action versions.

- Bump Documenter.jl compat

  Use newer Documenter features (or at least lay some groundwork for it).

- Add self to docs Project.toml

  Within docs/Project.toml, the dep points to "..", so that Pkg.jl can take care of it.

- Remove old format of parameter for makedocs

  `format = :html` removed because Documenter's `HTML` format is enabled by default.

- Fix up whitespace

  No actual reason for this one, just came across it.

- Update doc syntax highlight tag

  Use `julia-repl` to also highlight prompt and not highlight output.

- Use markdown URL syntax

  Remove duplication of links, let the URL be displayed as the link text.

- Add docs workflow

  Automatically deploy documentation.